### PR TITLE
gemを利用して、font-awesome、bootstrapをそれぞれインストール後、使用できるように設定しました。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'font-awesome-rails'
+gem 'bootstrap', '~> 4.1.1'
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,9 +46,15 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
+    autoprefixer-rails (10.2.5.1)
+      execjs (> 0)
     bindex (0.7.0)
     bootsnap (1.4.3)
       msgpack (~> 1.0)
+    bootstrap (4.1.3)
+      autoprefixer-rails (>= 6.0.3)
+      popper_js (>= 1.12.9, < 2)
+      sass (>= 3.5.2)
     builder (3.2.3)
     byebug (11.0.1)
     capybara (3.27.0)
@@ -74,6 +80,8 @@ GEM
     faker (1.9.6)
       i18n (>= 0.7)
     ffi (1.10.0)
+    font-awesome-rails (4.7.0.7)
+      railties (>= 3.2, < 7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.6.0)
@@ -82,6 +90,10 @@ GEM
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -108,6 +120,7 @@ GEM
     parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
+    popper_js (1.16.0)
     public_suffix (3.1.1)
     puma (3.12.1)
     rack (2.0.7)
@@ -232,11 +245,14 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  bootstrap (~> 4.1.1)
   byebug
   capybara
   factory_bot_rails
   faker
+  font-awesome-rails
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)
   rails (~> 5.2.3)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,9 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery3
+//= require popper
+//= require bootstrap-sprockets
 //= require rails-ujs
 //= require activestorage
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,5 @@
  *= require_tree .
  *= require_self
  */
+@import "font-awesome";
+@import "bootstrap";


### PR DESCRIPTION
## 概要

gemを利用して、font-awesome、bootstrapをそれぞれインストール後、使用できるように設定しました。

## 確認方法

1. Gem を追加したので `bundle install` を実行してください

## 影響範囲

webサイト上のレイアウト及びアイコンと、
ヘッダー部分のプルダウンメニュー、
フォーム入力部分に影響することが想定されます。

## チェックリスト

プロジェクトごとにパスしなければならないルールを定義しました。

- [ ] Bootstrapはver4系をインストールする
- [ ] font awesomeのgemをインストールする
- [ ] jqueryを使用できるように、application.jsを修正する
- [ ] bootstrapとfont awesomeを使用できるように、application.scssを修正する

## コメント

特にありません。